### PR TITLE
change docker in multi-stage mode to reduce size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE=intersystemsdc/irishealth-community
 ARG IMAGE=intersystemsdc/iris-community
 ARG IMAGE=intersystemsdc/iris-community:preview
-FROM $IMAGE
+FROM $IMAGE as builder
 
 WORKDIR /home/irisowner/dev
 
@@ -24,3 +24,11 @@ RUN --mount=type=bind,src=.,dst=. \
 	iris session IRIS < iris.script && \
     ([ $TESTS -eq 0 ] || iris session iris -U $NAMESPACE "##class(%ZPM.PackageManager).Shell(\"test $MODULE -v -only\",1,1)") && \
     iris stop IRIS quietly
+
+FROM $IMAGE as final
+
+ADD --chown=${ISC_PACKAGE_MGRUSER}:${ISC_PACKAGE_IRISGROUP} https://github.com/grongierisc/iris-docker-multi-stage-script/releases/latest/download/copy-data.py /irisdev/app/copy-data.py
+
+RUN --mount=type=bind,source=/,target=/builder/root,from=builder \
+    cp -f /builder/root/usr/irissys/iris.cpf /usr/irissys/iris.cpf && \
+    python3 /irisdev/app/copy-data.py -c /usr/irissys/iris.cpf -d /builder/root/ 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Examples. Import from file:
 USER>w ##class(shvarov.csvgenpy.csv).Generate("/home/irisowner/dev/data/countries.csv","countries")
 
 Import from URL:
-USER>do ##class(shvarov.csvgenpy.generate).Generate("https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv","titanic","data")
+USER>w ##class(shvarov.csvgenpy.csv).Generate("https://raw.githubusercontent.com/datasciencedojo/datasets/master/titanic.csv","titanic","data")
 
 Also can be called directly from python:
 $ irispython /home/irisowner/dev/app/csvgen.py


### PR DESCRIPTION
before
 csvgen-python-iris-1   793MB (virtual 4.09GB)
after
 csvgen-python-iris-1   793MB (virtual 3.43GB)
